### PR TITLE
Create Jekyll-docker.yml

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,0 +1,20 @@
+name: Jekyll site CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the site in the jekyll/builder container
+      run: |
+        docker run \
+        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
```yaml
version: '3'
services:
  jekyll:
    image: mslearn-tailspin-spacegame-web-deploy:latest
    volumes:
      - ./your_site_directory:/srv/jekyll
    ports:
      - "4000:4000"
    environment:
      - JEKYLL_ENV=development
```

In this configuration:

- `version: '3'` specifies the Docker Compose version.
- `jekyll` is the name of the service.
- `image: mslearn-tailspin-spacegame-web-deploy:latest` specifies the Docker image `mslearn-tailspin-spacegame-web-deploy`, assuming it's available on a Docker registry. Replace `latest` with a specific version tag if needed.
- `volumes` map your local site directory (replace `./your_site_directory` with your actual site directory) to the `/srv/jekyll` directory within the container, allowing you to make changes locally and see them reflected in the container.
- `ports` map port `4000` from the container to port `4000` on your host machine, so you can access the Jekyll site locally.
- `environment` sets the `JEKYLL_ENV` environment variable to `development` for development purposes. You can change it to `production` for a production build.

Save this configuration as `docker-compose.yml` in your Jekyll project directory. Then, open a terminal, navigate to your project directory, and run `docker-compose up`. This will start the Jekyll site using the specified Docker image.

Make sure the `mslearn-tailspin-spacegame-web-deploy` image is available and properly configured in your Docker environment before using this configuration.